### PR TITLE
Add modals for success and error messages instead of alerts

### DIFF
--- a/client/pages/join.jsx
+++ b/client/pages/join.jsx
@@ -3,11 +3,12 @@ import SectionBody from "../components/sectionbody";
 import SectionHead from "../components/sectionhead";
 import styles from "../styles/Forms.module.css";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import axios from "axios";
 import Container from "react-bootstrap/Container";
 import Form from "react-bootstrap/Form";
 import Button from "react-bootstrap/Button";
+import Modal from "react-bootstrap/Modal";
 
 import { base_url } from "../constants.js";
 
@@ -16,6 +17,12 @@ export default function Join() {
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [email, setEmail] = useState("");
+  const [modalSubscribed, setModalSubscribed] = useState(false);
+  const [modalError, setModalError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const toggleSubscribed = () => setModalSubscribed(!modalSubscribed);
+  const toggleError = () => setModalError(!modalError);
 
   const handleSubmit = (event) => {
     const url = base_url + "/subscriber";
@@ -34,18 +41,18 @@ export default function Join() {
       inputs.forEach((input) => (input.disabled = true));
 
       const postJoinRequest = async () => {
-        const result = await axios
+        await axios
           .post(url, {
             firstName: firstName,
             lastName: lastName,
             email: email,
           })
           .then((response) => {
-            alert("You have been subscribed to the newsletter. Thanks!");
-            console.log(response);
+            toggleSubscribed();
           })
           .catch((error) => {
-            alert("Error: " + error.message);
+            setErrorMessage(error.message);
+            toggleError();
           })
           .finally(() => {
             inputs.forEach((input) => (input.disabled = false));
@@ -166,6 +173,16 @@ export default function Join() {
                 Submit
               </Button>
             </Form>
+            <Modal show={modalSubscribed} onHide={toggleSubscribed}>
+              <Modal.Header closeButton>Successfully subscribed</Modal.Header>
+              <Modal.Body>
+                Thank you for subscribing to the WECE newsletter!
+              </Modal.Body>
+            </Modal>
+            <Modal show={modalError} onHide={toggleError}>
+              <Modal.Header closeButton>Error subscribing</Modal.Header>
+              <Modal.Body>{errorMessage}</Modal.Body>
+            </Modal>
           </SectionBody>
         </Container>
       </div>


### PR DESCRIPTION
<!--
How to name the pull request:
If still a work in progress, add [WIP] to the beginning of the name.
Name the pull request with a succint description of the changes made.
-->

## Status: :rocket:

<!--
Use one of these symbols to note the status of the pull request:
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

<!--
Write a few sentences describing the overall goals of and changes in the pull request's commits.
-->
Instead of browser alerts, use Bootstrap modals to notify user on success or failure of submitting the join form.

## Screenshots

<!--
Add screenshots of the changes (if applicable)
-->
<img width="1312" alt="Screen Shot 2020-12-28 at 1 17 20 PM" src="https://user-images.githubusercontent.com/7256863/103238036-16c0c000-490f-11eb-975c-4148d2c2cd33.png">

<img width="1312" alt="Screen Shot 2020-12-28 at 1 17 38 PM" src="https://user-images.githubusercontent.com/7256863/103238028-11637580-490f-11eb-97e2-74108c516a50.png">

